### PR TITLE
Check nvim-tree before subscribing it's events in plugin.lua

### DIFF
--- a/lua/unity/plugin.lua
+++ b/lua/unity/plugin.lua
@@ -20,8 +20,6 @@ if not ok then
 end
 
 local unityProject = xmlHandler:new()
-local nvimtreeApi = require("nvim-tree.api")
-local Event = nvimtreeApi.events.Event
 local lspAttached = false
 
 local function trySaveProject()
@@ -33,98 +31,105 @@ end
 
 --------------- Nvim-tree Events --------------------
 
-nvimtreeApi.events.subscribe(Event.FileCreated, function(data)
-	if lspAttached then
-		return
-	end
+local has_nvimtree, nvimtreeApi = pcall(require, "nvim-tree.api")
+if not has_nvimtree then
+    vim.notify("[NvimUnity] Failed to load nvim-tree.api", vim.log.levels.INFO)
+else
+    Event = nvimtreeApi.events.Event
 
-  if not utils.isCSFile(data.fname) then
-    return
-  end
+    nvimtreeApi.events.subscribe(Event.FileCreated, function(data)
+        if lspAttached then
+            return
+        end
 
-	if not unityProject:validateProject() then
-		return
-	end
+        if not utils.isCSFile(data.fname) then
+            return
+        end
 
-	local folderName = utils.cutPath(utils.normalizePath(data.fname), "Assets") or ""
-	if unityProject:addCompileTag(folderName) then
-    if config.unity_cs_template then
-		  utils.insertCSTemplate(data.fname)
-    end
-		trySaveProject()
-	end
-end)
+        if not unityProject:validateProject() then
+            return
+        end
 
-nvimtreeApi.events.subscribe(Event.FileRemoved, function(data)
-	if lspAttached then
-		return
-	end
+        local folderName = utils.cutPath(utils.normalizePath(data.fname), "Assets") or ""
+        if unityProject:addCompileTag(folderName) then
+            if config.unity_cs_template then
+                utils.insertCSTemplate(data.fname)
+            end
+            trySaveProject()
+        end
+    end)
 
-  if not utils.isCSFile(data.fname) then
-    return
-  end
-  
-	if not unityProject:validateProject() then
-		return
-	end
+    nvimtreeApi.events.subscribe(Event.FileRemoved, function(data)
+        if lspAttached then
+            return
+        end
 
-	local folderName = utils.cutPath(utils.normalizePath(data.fname), "Assets") or ""
-	if unityProject:removeCompileTag(folderName) then
-		trySaveProject()
-	end
-end)
+        if not utils.isCSFile(data.fname) then
+            return
+        end
 
-nvimtreeApi.events.subscribe(Event.WillRenameNode, function(data)
-	if not unityProject:validateProject() then
-		return
-	end
+        if not unityProject:validateProject() then
+            return
+        end
 
-	if utils.isDirectory(data.old_name) then
-		local updatedFileNames = utils.getUpdatedCSFilesNames(data.old_name, data.new_name)
-		if #updatedFileNames == 0 then
-			return
-		end
+        local folderName = utils.cutPath(utils.normalizePath(data.fname), "Assets") or ""
+        if unityProject:removeCompileTag(folderName) then
+            trySaveProject()
+        end
+    end)
 
-		local nameChanges = {}
-		for _, file in ipairs(updatedFileNames) do
-			table.insert(nameChanges, {
-				old = utils.cutPath(utils.normalizePath(file.old), "Assets") or "",
-				new = utils.cutPath(utils.normalizePath(file.new), "Assets") or "",
-			})
-		end
+    nvimtreeApi.events.subscribe(Event.WillRenameNode, function(data)
+        if not unityProject:validateProject() then
+            return
+        end
 
-		unityProject:updateCompileTags(nameChanges)
-		trySaveProject()
-	else
-		if lspAttached then
-		  return
-  end
-    if not utils.isCSFile(data.old_name) and utils.isCSFile(data.new_name) then
-      return
-    end
+        if utils.isDirectory(data.old_name) then
+            local updatedFileNames = utils.getUpdatedCSFilesNames(data.old_name, data.new_name)
+            if #updatedFileNames == 0 then
+                return
+            end
 
-		local nameChanges = {
-			{
-				old = utils.cutPath(utils.normalizePath(data.old_name), "Assets") or "",
-				new = utils.cutPath(utils.normalizePath(data.new_name), "Assets") or "",
-			},
-		}
+            local nameChanges = {}
+            for _, file in ipairs(updatedFileNames) do
+                table.insert(nameChanges, {
+                    old = utils.cutPath(utils.normalizePath(file.old), "Assets") or "",
+                    new = utils.cutPath(utils.normalizePath(file.new), "Assets") or "",
+                })
+            end
 
-		unityProject:updateCompileTags(nameChanges)
-		trySaveProject()
-	end
-end)
+            unityProject:updateCompileTags(nameChanges)
+            trySaveProject()
+        else
+            if lspAttached then
+                return
+            end
+            if not utils.isCSFile(data.old_name) and utils.isCSFile(data.new_name) then
+                return
+            end
 
-nvimtreeApi.events.subscribe(Event.FolderRemoved, function(data)
-	if not unityProject:validateProject() then
-		return
-	end
+            local nameChanges = {
+                {
+                    old = utils.cutPath(utils.normalizePath(data.old_name), "Assets") or "",
+                    new = utils.cutPath(utils.normalizePath(data.new_name), "Assets") or "",
+                },
+            }
 
-	local folderName = utils.cutPath(utils.normalizePath(data.folder_name), "Assets") or ""
-	if unityProject:removeCompileTagsByFolder(folderName) then
-		trySaveProject()
-	end
-end)
+            unityProject:updateCompileTags(nameChanges)
+            trySaveProject()
+        end
+    end)
+
+    nvimtreeApi.events.subscribe(Event.FolderRemoved, function(data)
+        if not unityProject:validateProject() then
+            return
+        end
+
+        local folderName = utils.cutPath(utils.normalizePath(data.folder_name), "Assets") or ""
+        if unityProject:removeCompileTagsByFolder(folderName) then
+            trySaveProject()
+        end
+    end)
+end
 
 --------------- Auto Commands --------------------
 


### PR DESCRIPTION
change `lua/untiy/plugin.lua` to check if `nvim-tree` is available prior to
subscribing to it's events. If it's not the plugin logs this:

```
[NvimUnity] Failed to load nvim-tree.api
```

Closes #2